### PR TITLE
fix: resolve ESLint warnings

### DIFF
--- a/src/screens/Companies/Details/utils/modals/ModalEditCompanyAndOwner/utils/functions.ts
+++ b/src/screens/Companies/Details/utils/modals/ModalEditCompanyAndOwner/utils/functions.ts
@@ -130,7 +130,7 @@ export const schemaModalEditCompanyAndOwnerWithCPFAndCNPJ = yup
 
     CPF: yup
       .string()
-      .test('cpf-or-cnpj', 'Um CPF ou CNPJ deve ser preenchido', function (value) {
+      .test('cpf-or-cnpj', 'Um CPF ou CNPJ deve ser preenchido', function validateCpfOrCnpj(value) {
         const { CNPJ } = this.parent;
         if (value && value.length > 0) return true;
         if (CNPJ && CNPJ.length > 0) return true;
@@ -144,7 +144,7 @@ export const schemaModalEditCompanyAndOwnerWithCPFAndCNPJ = yup
 
     CNPJ: yup
       .string()
-      .test('cpf-or-cnpj', 'Um CPF ou CNPJ deve ser preenchido', function (value) {
+      .test('cpf-or-cnpj', 'Um CPF ou CNPJ deve ser preenchido', function validateCnpjOrCpf(value) {
         const { CPF } = this.parent;
         if (value && value.length > 0) return true;
         if (CPF && CPF.length > 0) return true;

--- a/src/screens/Guarantees/FailureTypesList/index.tsx
+++ b/src/screens/Guarantees/FailureTypesList/index.tsx
@@ -228,6 +228,7 @@ export const FailureTypesList = () => {
                       cell: (
                         <TableCell
                           type="string"
+                          // eslint-disable-next-line no-underscore-dangle
                           value={item?._count?.guaranteeToFailureTypes || ''}
                           alignItems="center"
                         />

--- a/src/screens/Guarantees/SystemsList/index.tsx
+++ b/src/screens/Guarantees/SystemsList/index.tsx
@@ -224,6 +224,7 @@ export const SystemsList = () => {
                     cell: (
                       <TableCell
                         type="string"
+                        // eslint-disable-next-line no-underscore-dangle
                         value={item._count.guarantees || ''}
                         alignItems="center"
                       />


### PR DESCRIPTION
- Add function names to Yup validation functions in ModalEditCompanyAndOwner
- Add ESLint disable comments for Prisma _count properties in FailureTypesList and SystemsList
- Fix func-names and no-underscore-dangle warnings

Resolves SE-707